### PR TITLE
🚨 Resolver problema de 'eol' no eslint para Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,7 +30,12 @@ module.exports = {
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
     'write-good-comments/write-good-comments': 'warn',
-    'prettier/prettier': ['error'],
+    'prettier/prettier': [
+      'error',
+      {
+        endOfLine: 'auto',
+      },
+    ],
     '@next/next/no-html-link-for-pages': 'off',
     'react/jsx-key': 'off',
     'simple-import-sort/imports': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,12 +30,7 @@ module.exports = {
       { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
     ],
     'write-good-comments/write-good-comments': 'warn',
-    'prettier/prettier': [
-      'error',
-      {
-        endOfLine: 'auto',
-      },
-    ],
+    'prettier/prettier': ['error'],
     '@next/next/no-html-link-for-pages': 'off',
     'react/jsx-key': 'off',
     'simple-import-sort/imports': [

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -4,5 +4,6 @@
   "printWidth": 80,
   "singleQuote": true,
   "trailingComma": "es5",
-  "jsxBracketSameLine": false
+  "jsxBracketSameLine": false,
+  "endOfLine": "auto"
 }


### PR DESCRIPTION
No Windows, a caractere de final de linha é `CRLF`, mas no Unix é apenas `LF`, por causa disso, o eslint `prettier/prettier` tenta fazer com que o único caractere possível para final de linha seja o `LF`, baseado nas suas configurações.

Pra resolver isso, basta adicionar isso pra o seu ` .prettierrc.json`:

```js
  "endOfLine": "auto"
```

Desse jeito, os 2 finais vao ser permitidos: `CRLF` ou `LF`