### PR TITLE
Limpar formulário após sucesso

### DIFF
--- a/src/components/pages/posts/mutationPostModal.tsx
+++ b/src/components/pages/posts/mutationPostModal.tsx
@@ -2,6 +2,8 @@
 import { Fragment, useEffect, useState } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 
+import { THandleCreatePost } from '@root/pages/posts';
+
 import { tagCheckboxHandler } from './checkboxHeader';
 
 export function MutationPostModal({
@@ -14,15 +16,7 @@ export function MutationPostModal({
 }: {
   title: string;
   openModal: boolean;
-  callback: ({
-    description,
-    tags,
-    visible,
-  }: {
-    description: string;
-    tags: string[];
-    visible: boolean;
-  }) => void;
+  callback: THandleCreatePost;
   onClose: () => void;
   description: string;
   tags: string[];
@@ -77,11 +71,21 @@ export function MutationPostModal({
                     onSubmit={(e) => {
                       e.preventDefault();
                       if (description.trim().length > 0) {
-                        callback({
-                          description,
-                          tags: Array.from(new Set(tags)),
-                          visible,
-                        });
+                        callback(
+                          {
+                            description,
+                            tags: Array.from(new Set(tags)),
+                            visible,
+                          },
+                          {
+                            onSuccess: () => {
+                              // reset all fields
+                              setDescription('');
+                              setTags([]);
+                              setPostAsPublic(false);
+                            },
+                          }
+                        );
                       }
                     }}
                   >

--- a/src/components/pages/posts/mutationPostModal.tsx
+++ b/src/components/pages/posts/mutationPostModal.tsx
@@ -99,7 +99,7 @@ export function MutationPostModal({
                             type="checkbox"
                             defaultChecked={tags.includes('furto')}
                             className="checkbox mr-2"
-                            onClick={(e) =>
+                            onChange={(e) =>
                               handleCheckbox({
                                 checked: e.target?.checked,
                                 value: 'furto',
@@ -115,7 +115,7 @@ export function MutationPostModal({
                             type="checkbox"
                             defaultChecked={tags.includes('roubo')}
                             className="checkbox mr-2"
-                            onClick={(e) =>
+                            onChange={(e) =>
                               handleCheckbox({
                                 checked: e.target?.checked,
                                 value: 'roubo',
@@ -131,7 +131,7 @@ export function MutationPostModal({
                             type="checkbox"
                             defaultChecked={tags.includes('assédio')}
                             className="checkbox mr-2"
-                            onClick={(e) =>
+                            onChange={(e) =>
                               handleCheckbox({
                                 checked: e.target?.checked,
                                 value: 'assédio',

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -17,15 +17,12 @@ import {
 } from '@root/components';
 import { trpc } from '@root/utils/trpc';
 
-// I use "T" before the name of all types to avoid confusion with functions
-// also not needed, you can change it as you want to
 type TCreatePostData = {
   description: string;
   tags: string[];
   visible: boolean;
 };
 
-// exporting for using it inside other components
 export type THandleCreatePost = (
   data: TCreatePostData,
   { onSuccess }: { onSuccess: (post: PrismaPost) => void }
@@ -96,8 +93,9 @@ function useMutationsPostModal({
   });
 
   const handleCreatePost: THandleCreatePost = (postData, { onSuccess }) => {
-    // You can add other functions as onError, onSettled also, but if you do,
-    // you need to add it to the THandleCreatePost type
+    // All functions as onError, onSettled, onSuccess are here if you want,
+    // but you need to add it to the THandleCreatePost type as I did with
+    // onSuccess
     createPost(postData, { onSuccess: (post) => onSuccess(post) });
   };
 

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -92,13 +92,6 @@ function useMutationsPostModal({
     },
   });
 
-  const handleCreatePost: THandleCreatePost = (postData, { onSuccess }) => {
-    // All functions as onError, onSettled, onSuccess are here if you want,
-    // but you need to add it to the THandleCreatePost type as I did with
-    // onSuccess
-    createPost(postData, { onSuccess: (post) => onSuccess(post) });
-  };
-
   return {
     openCreateModal,
     setOpenCreateModal,
@@ -106,7 +99,7 @@ function useMutationsPostModal({
     setOpenEditModal,
     editPost,
     deletePost,
-    handleCreatePost,
+    createPost,
   };
 }
 
@@ -141,7 +134,7 @@ const Posts: NextPage = () => {
   const {
     openCreateModal,
     setOpenCreateModal,
-    handleCreatePost,
+    createPost,
     openEditModal,
     setOpenEditModal,
     editPost,
@@ -247,7 +240,7 @@ const Posts: NextPage = () => {
         <MutationPostModal
           title={'Criar Novo Post'}
           openModal={openCreateModal}
-          callback={handleCreatePost}
+          callback={createPost}
           tags={[] as string[]}
           description={''}
           onClose={() => setOpenCreateModal(false)}

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,6 +1,7 @@
 /* eslint-disable i18next/no-literal-string */
 /* eslint-disable abcsize/abcsize */
 import { useState } from 'react';
+import type { Post as PrismaPost } from '@prisma/client';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 import { useSession } from 'next-auth/react';
@@ -15,6 +16,20 @@ import {
   tagCheckboxHandler,
 } from '@root/components';
 import { trpc } from '@root/utils/trpc';
+
+// I use "T" before the name of all types to avoid confusion with functions
+// also not needed, you can change it as you want to
+type TCreatePostData = {
+  description: string;
+  tags: string[];
+  visible: boolean;
+};
+
+// exporting for using it inside other components
+export type THandleCreatePost = (
+  data: TCreatePostData,
+  { onSuccess }: { onSuccess: (post: PrismaPost) => void }
+) => void;
 
 function AddSymbolSVG() {
   return (
@@ -80,14 +95,20 @@ function useMutationsPostModal({
     },
   });
 
+  const handleCreatePost: THandleCreatePost = (postData, { onSuccess }) => {
+    // You can add other functions as onError, onSettled also, but if you do,
+    // you need to add it to the THandleCreatePost type
+    createPost(postData, { onSuccess: (post) => onSuccess(post) });
+  };
+
   return {
     openCreateModal,
     setOpenCreateModal,
-    createPost,
     openEditModal,
     setOpenEditModal,
     editPost,
     deletePost,
+    handleCreatePost,
   };
 }
 
@@ -122,7 +143,7 @@ const Posts: NextPage = () => {
   const {
     openCreateModal,
     setOpenCreateModal,
-    createPost,
+    handleCreatePost,
     openEditModal,
     setOpenEditModal,
     editPost,
@@ -228,7 +249,7 @@ const Posts: NextPage = () => {
         <MutationPostModal
           title={'Criar Novo Post'}
           openModal={openCreateModal}
-          callback={createPost}
+          callback={handleCreatePost}
           tags={[] as string[]}
           description={''}
           onClose={() => setOpenCreateModal(false)}


### PR DESCRIPTION
Essa pull request resolve a issue #7.

Criei uma função que pega o `onSuccess` do próprio TRPC e você pode fazer o que quiser com ela. Usei para resetar os campos do formulário, usando os próprios estados. Comentei dentro do código pra ficar melhor explicado como usar as outras funções como `onError`, `onSettled` se você achar útil usar.

**_Obs1.:_ Usei minha convenção para nomear os tipos, mas claro, você pode mudar.
_Obs2.:_ Alterei o `onClick` do checkbox para `onChange`, já que o TypeScript tava dando erro, mesmo funcionando e funciona da mesma maneira do `onClick`.**

fixes #7